### PR TITLE
DEMO Release v.0.1 - Initial Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:21-jdk
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+
+  db:
+    image: mariadb:latest
+    container_name: educabinet_db
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: educabinet_db
+      MARIADB_USER: educabinet_user
+      MARIADB_PASSWORD: educabinet_user
+    volumes:
+      - mariadb_data:/var/lib/mysql
+
+  app:
+    build: .
+    container_name: educabinet_app
+    restart: on-failure
+    ports:
+      - "8000:8000"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mariadb://db:3306/educabinet_db
+      SPRING_DATASOURCE_USERNAME: educabinet_user
+      SPRING_DATASOURCE_PASSWORD: educabinet_user
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+    depends_on:
+      - db
+
+volumes:
+  mariadb_data:


### PR DESCRIPTION
This pull request introduces Docker support for the project, enabling containerized deployment of both the application and its database. The changes add a `Dockerfile` for building the application image and a `docker-compose.yml` file to orchestrate the application and a MariaDB database as services.

**Dockerization and container orchestration:**

* Added a `Dockerfile` that builds the application using the Eclipse Temurin JDK 21 base image, copies the built JAR file, and sets up the entrypoint to run the app with Java.
* Added a `docker-compose.yml` file that defines two services:
  * `db`: Runs a MariaDB container with persistent storage and environment variables for database setup.
  * `app`: Builds the application image, exposes port 8000, sets environment variables for Spring datasource configuration, and depends on the `db` service.
  * Also defines a named volume for MariaDB data persistence.